### PR TITLE
modified a typo　'articals' → 'articles'

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ export default {
   mounted() {
   document.querySelector(
     'div.info-wrapper > div.personal-info-wrapper > div > div:nth-child(1) > h6'
-  ).innerText = 'articals';
+  ).innerText = 'articles';
   document.querySelector(
     'div.info-wrapper > div.personal-info-wrapper > div > div:nth-child(2) > h6'
   ).innerText = 'tags';


### PR DESCRIPTION
When I tried to change the language of the sidebar in my blog referencing this repository, I found a typo.
By the way, Do we have any solution to change a language without coding like 'document.selector....'?